### PR TITLE
ci: point workflows at strongo/cicd (renamed from go-ci-action)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,6 @@ jobs:
 
       - run: gcloud version
 
-      - uses: strongo/go-ci-action@v1.6.0
+      - uses: strongo/cicd@v1.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
strongo/go-ci-action was renamed to strongo/cicd. Old refs redirect, this updates them explicitly. Trivial workflow-ref change.