### PR TITLE
ci: point workflows at strongo/cicd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,6 @@ jobs:
 
       - run: gcloud version
 
-      - uses: strongo/go-ci-action@v1.6.3
+      - uses: strongo/cicd@v1.6.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
strongo/go-ci-action renamed to strongo/cicd; @v1.6.3 tag preserved through the rename.