### PR TITLE
ci: use fixed strongo release action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Go CI
 on:
   push:
     branches: ['**']
-    tags: ['v[0-9]+\.[0-9]+\.[0-9]+']
+    tags: ['v*.*.*']
 
 jobs:
 
@@ -34,6 +34,6 @@ jobs:
 
       - run: gcloud version
 
-      - uses: strongo/cicd@v1.10.3
+      - uses: strongo/cicd@v1.10.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- update the shared release action from strongo/cicd@v1.10.3 to the fixed v1.10.4
- correct the GitHub Actions tag filter to v*.*.* so semantic-version tags trigger CI

## Verification

- actionlint .github/workflows/ci.yml
- go test .
- go vet ./...
- go mod verify
- go test ./... reaches the end-to-end package but the local Datastore emulator cannot start because Java is unavailable; CI provisions Temurin JRE 24 and exercises this gate
